### PR TITLE
Multiple fixes

### DIFF
--- a/loginsight/loginsight.go
+++ b/loginsight/loginsight.go
@@ -19,10 +19,17 @@ type LogInsight struct {
 	LogInsightReservedFields []string
 	LogInsightAgentID        *string
 	Messages                 Messages
+	LogInsightClient         *http.Client
 }
 
 //NewLogging - Creates new instance of LogInsight that implments logging.Logging interface
 func NewLogging(logInsightServer *string, logInsightPort, logInsightBatchSize *int, logInsightReservedFields *string, logInsightAgentID *string) logging.Logging {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	baseClient := &http.Client{Transport: tr}
+
 	return &LogInsight{
 		LogInsightServer:         logInsightServer,
 		LogInsightPort:           logInsightPort,
@@ -30,6 +37,7 @@ func NewLogging(logInsightServer *string, logInsightPort, logInsightBatchSize *i
 		LogInsightReservedFields: strings.Split(*logInsightReservedFields, ","),
 		LogInsightAgentID:        logInsightAgentID,
 		Messages:                 Messages{},
+		LogInsightClient:         baseClient,
 	}
 }
 
@@ -53,6 +61,7 @@ func contains(s []string, e string) bool {
 	}
 	return false
 }
+
 func (l *LogInsight) ShipEvents(eventFields map[string]interface{}, msg string) {
 	message := Message{
 		Text: msg,
@@ -64,39 +73,55 @@ func (l *LogInsight) ShipEvents(eventFields map[string]interface{}, msg string) 
 			message.Fields = append(message.Fields, Field{Name: l.CreateKey(k), Content: fmt.Sprint(v)})
 		}
 	}
-	l.Messages.Messages = append(l.Messages.Messages, message)
 
+	l.Messages.Messages = append(l.Messages.Messages, message)
 	if len(l.Messages.Messages) >= *l.LogInsightBatchSize {
-		if jsonstr, err := json.Marshal(l.Messages); err == nil {
+
+		jsonBuffer := new(bytes.Buffer)
+		encoder := json.NewEncoder(jsonBuffer)
+
+		if err := encoder.Encode(l.Messages); err == nil {
 			url := fmt.Sprintf("https://%s:%d/api/v1/messages/ingest/%s", *l.LogInsightServer, *l.LogInsightPort, *l.LogInsightAgentID)
-			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}
+
 			var req *http.Request
-			var resp *http.Response
-			if req, err = http.NewRequest("POST", url, bytes.NewBuffer(jsonstr)); err == nil {
+			if req, err = http.NewRequest("POST", url, jsonBuffer); err == nil {
+				defer req.Body.Close()
+
 				req.Header.Add("Content-Type", "application/json")
-				client := &http.Client{Transport: tr}
-				if resp, err = client.Do(req); err == nil {
-					defer resp.Body.Close()
-					if resp.StatusCode != 200 {
-						body, _ := ioutil.ReadAll(resp.Body)
-						logging.LogError(fmt.Sprintf("Error posting data to log insight with status %d and payload %s", resp.StatusCode, string(jsonstr)), string(body))
-						fmt.Println("response Status:", resp.Status)
-						fmt.Println("response Headers:", resp.Header)
-						fmt.Println("response Body:", string(body))
-					} else {
-						l.Messages = Messages{}
-					}
-				} else {
-					logging.LogError("Error sending data", err)
-				}
+				go l.handleLogInsightResponse(req, jsonBuffer)
 			} else {
 				logging.LogError("Error creating request", err)
 			}
 		} else {
 			logging.LogError("Error marshalling", err)
 		}
+
+		jsonBuffer = nil
+		encoder = nil
+	}
+
+	message.Fields = nil
+	l.Messages.Messages = nil
+}
+
+func (l *LogInsight) handleLogInsightResponse(req *http.Request, jsonBuffer *bytes.Buffer) func() {
+	return func() {
+		if resp, err := l.LogInsightClient.Do(req); err == nil {
+			defer resp.Body.Close()
+
+			if resp.StatusCode != 200 {
+				body, _ := ioutil.ReadAll(resp.Body)
+				logging.LogError(fmt.Sprintf("Error posting data to log insight with status %d and payload %s", resp.StatusCode, jsonBuffer.String()), string(body))
+				fmt.Println("response Status:", resp.Status)
+				fmt.Println("response Headers:", resp.Header)
+				fmt.Println("response Body:", string(body))
+			} else {
+				l.Messages = Messages{}
+			}
+		} else {
+			logging.LogError("Error sending data", err)
+		}
+		jsonBuffer = nil
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var (
 	logInsightBatchSize      = kingpin.Flag("insight-batch-size", "log insight batch size").Default("1").OverrideDefaultFromEnvar("INSIGHT_BATCH_SIZE").Int()
 	logInsightReservedFields = kingpin.Flag("insight-reserved-fields", "comma delimited list of fields that are reserved").Default("event_type").OverrideDefaultFromEnvar("INSIGHT_RESERVED_FIELDS").String()
 	logInsightAgentID        = kingpin.Flag("insight-agent-id", "agent id for log insight").Default("5").OverrideDefaultFromEnvar("INSIGHT_AGENT_ID").String()
+	logInsightHasJsonLogMsg  = kingpin.Flag("insight-has-json-log-msg", "app log message can be json").Default("false").OverrideDefaultFromEnvar("INSIGHT_HAS_JSON_LOG_MSG").String()
 )
 
 var (
@@ -46,7 +47,7 @@ func main() {
 
 	var loggingClient logging.Logging
 	//Setup Logging
-	loggingClient = loginsight.NewLogging(logInsightServer, logInsightServerPort, logInsightBatchSize, logInsightReservedFields, logInsightAgentID)
+	loggingClient = loginsight.NewLogging(logInsightServer, logInsightServerPort, logInsightBatchSize, logInsightReservedFields, logInsightAgentID, logInsightHasJsonLogMsg)
 	logging.LogStd(fmt.Sprintf("Starting firehose-to-loginsight %s ", VERSION), true)
 
 	c := cfclient.Config{


### PR DESCRIPTION
* Fixed additive message combination (where m1 would have itself and m2 would have m1 and m2, etc)
* Fixed memory leaks surrounding use of `net/http.Client`
* Pulled client into struct and separate method for `client.Do` to avoid websocket `PING/PONG` being blocked until timeout
* Added a flag to let `LogMessage`s be parsed as JSON and ingested in LogInsight as fields if desired (`INSIGHT_HAS_JSON_LOG_MSG` env var or `--insight-has-json-log-msg` flag)

Testing:
Ran in lab for 18 hours with 8.9 million events (all types), with no heap growth or app crashes.